### PR TITLE
Avoid sending network Ids if not specified

### DIFF
--- a/virtualmachine.go
+++ b/virtualmachine.go
@@ -18,7 +18,9 @@ func (c CloudstackClient) DeployVirtualMachine(serviceofferingid string, templat
 	params.Set("diskofferingid", diskofferingid)
 	params.Set("displayname", displayname)
 	params.Set("hypervisor", hypervisor)
-	params.Set("networkids", strings.Join(networkids, ","))
+	if len(networkids) > 0 {
+		params.Set("networkids", strings.Join(networkids, ","))
+	}
 	params.Set("keypair", keypair)
 	//	params.Set("projectid", projectid)
 	if userdata != "" {


### PR DESCRIPTION
Specifying network Ids in Basic zone is not allowed. Passing
an empty array of network Ids is not enough as the empty parameter
will still be sent triggering an error. We have to completely avoid
sending the parameter in case the network Ids array is empty.
