### PR TITLE
Tweak escaping of param keys for signature, fix tag param keys

### DIFF
--- a/client.go
+++ b/client.go
@@ -53,12 +53,13 @@ func NewRequest(c CloudstackClient, request string, params url.Values) (interfac
 	// Generate signature for API call
 	// * Serialize parameters and sort them by key, done by Encode()
 	// * Use byte sequence for '+' character as Cloudstack requires this
+	// * For the signature only, un-encode [ and ].
 	// * Convert the entire argument string to lowercase
 	// * Calculate HMAC SHA1 of argument string with Cloudstack secret key
 	// * URL encode the string and convert to base64
 	s := params.Encode()
 	s2 := strings.Replace(s, "+", "%20", -1)
-	s3 := strings.ToLower(s2)
+	s3 := strings.ToLower(strings.Replace(strings.Replace(s2, "%5B", "[", -1), "%5D", "]", -1))
 	mac := hmac.New(sha1.New, []byte(c.SecretKey))
 	mac.Write([]byte(s3))
 	signature := base64.StdEncoding.EncodeToString(mac.Sum(nil))

--- a/tag.go
+++ b/tag.go
@@ -14,8 +14,8 @@ func (c CloudstackClient) CreateTags(options *CreateTags) (CreateTagsResponse, e
 	params.Set("resourceids", strings.Join(options.Resourceids, ","))
 	params.Set("resourcetype", options.Resourcetype)
 	for j, tag := range options.Tags {
-		params.Set("tag["+strconv.Itoa(j+1)+"].key", tag.Key)
-		params.Set("tag["+strconv.Itoa(j+1)+"].value", tag.Value)
+		params.Set("tags["+strconv.Itoa(j+1)+"].key", tag.Key)
+		params.Set("tags["+strconv.Itoa(j+1)+"].value", tag.Value)
 	}
 
 	if options.Customer != "" {
@@ -39,8 +39,8 @@ func (c CloudstackClient) DeleteTags(options *DeleteTags) (DeleteTagsResponse, e
 	params.Set("resourceids", strings.Join(options.Resourceids, ","))
 	params.Set("resourcetype", options.Resourcetype)
 	for j, tag := range options.Tags {
-		params.Set("tag["+strconv.Itoa(j+1)+"].key", tag.Key)
-		params.Set("tag["+strconv.Itoa(j+1)+"].value", tag.Value)
+		params.Set("tags["+strconv.Itoa(j+1)+"].key", tag.Key)
+		params.Set("tags["+strconv.Itoa(j+1)+"].value", tag.Value)
 	}
 
 	response, err := NewRequest(c, "deleteTags", params)


### PR DESCRIPTION
So first I had "tag[" where I should have had "tags[" - easy fix. Next I discovered that params.Encode() created a string that was the right thing for the actual request URL, but not right for the signature generation - CloudStack's expecting the parameter keys to still be unencoded, apparently. So I added a tweak to unencode the [ and ] characters for the string used to generate the signature, but not the string used for the actual URL.
