### PR TITLE
on error, also print body

### DIFF
--- a/client.go
+++ b/client.go
@@ -84,7 +84,7 @@ func NewRequest(c CloudstackClient, request string, params url.Values) (interfac
 
 	log.Printf("Response from Cloudstack: %d - %s", resp.StatusCode, body)
 	if resp.StatusCode != 200 {
-		err = errors.New(fmt.Sprintf("Received HTTP client/server error from Cloudstack: %d", resp.StatusCode))
+		err = errors.New(fmt.Sprintf("Received HTTP client/server error from Cloudstack: %d - %s", resp.StatusCode, body))
 		return nil, err
 	}
 


### PR DESCRIPTION
Hi

On error, it's very useful to have the full description.
Before this PR, on error we have the following message: 

> Received HTTP client/server error from Cloudstack: 431 

Now

> Received HTTP client/server error from Cloudstack: 431 - { "deployvirtualmachineresponse" : {"uuidList":[],"errorcode":431,"cserrorcode":4350,"errortext":"Can't specify network Ids in Basic zone"} }

Cheers
