### PR TITLE
Not setting diskoffering if it is an empty string

### DIFF
--- a/virtualmachine.go
+++ b/virtualmachine.go
@@ -15,7 +15,9 @@ func (c CloudstackClient) DeployVirtualMachine(serviceofferingid string, templat
 	params.Set("templateid", templateid)
 	params.Set("zoneid", zoneid)
 	//	params.Set("account", account)
-	params.Set("diskofferingid", diskofferingid)
+	if diskofferingid != "" {
+		params.Set("diskofferingid", diskofferingid)
+	}
 	params.Set("displayname", displayname)
 	params.Set("hypervisor", hypervisor)
 	if len(networkids) > 0 {


### PR DESCRIPTION
In the past it was ok to send diskoffering as an empty string. Current version of cloudstack raises an error.
